### PR TITLE
Fixed poly/tri/quadmarks to build with GCC12

### DIFF
--- a/samples/polymark/main.c
+++ b/samples/polymark/main.c
@@ -100,7 +100,7 @@ void do_frame() {
     glKosSwapBuffers();
 }
 
-time_t start;
+time_t begin;
 void switch_tests(int ppf) {
     printf("Beginning new test: %d polys per frame (%d per second at 60fps)\n",
            ppf * 3, ppf * 3 * 60);
@@ -113,8 +113,8 @@ void check_switch() {
 
     now = time(NULL);
 
-    if(now >= (start + 5)) {
-        start = time(NULL);
+    if(now >= (begin + 5)) {
+        begin = time(NULL);
         printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
 
     /* Start off with something obscene */
     switch_tests(200000 / 60);
-    start = time(NULL);
+    begin = time(NULL);
 
     for(;;) {
         if(check_start())

--- a/samples/quadmark/main.c
+++ b/samples/quadmark/main.c
@@ -112,7 +112,7 @@ void do_frame() {
     glKosSwapBuffers();
 }
 
-time_t start;
+time_t begin;
 void switch_tests(int ppf) {
     printf("Beginning new test: %d polys per frame (%d per second at 60fps)\n",
            ppf * 2, ppf * 2 * 60);
@@ -125,8 +125,8 @@ void check_switch() {
 
     now = time(NULL);
 
-    if(now >= (start + 5)) {
-        start = time(NULL);
+    if(now >= (begin + 5)) {
+        begin = time(NULL);
         printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
 
     /* Start off with something obscene */
     switch_tests(200000 / 60);
-    start = time(NULL);
+    begin = time(NULL);
 
     uint32_t iterations = 2000;
 

--- a/samples/trimark/main.c
+++ b/samples/trimark/main.c
@@ -93,7 +93,7 @@ void do_frame() {
     glKosSwapBuffers();
 }
 
-time_t start;
+time_t begin;
 void switch_tests(int ppf) {
     printf("Beginning new test: %d polys per frame (%d per second at 60fps)\n",
            ppf * 2, ppf * 2 * 60);
@@ -106,8 +106,8 @@ void check_switch() {
 
     now = time(NULL);
 
-    if(now >= (start + 5)) {
-        start = time(NULL);
+    if(now >= (begin + 5)) {
+        begin = time(NULL);
         printf("  Average Frame Rate: ~%f fps (%d pps)\n", avgfps, (int)(polycnt * avgfps * 2));
 
         switch(phase) {
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
 
     /* Start off with something obscene */
     switch_tests(220000 / 60);
-    start = time(NULL);
+    begin = time(NULL);
 
     for(;;) {
         if(check_start())


### PR DESCRIPTION
"start" is a reserved symbol within KOS, per crt1.s. Not sure why the old toolchains let us use this symbol name elsewhere, but the new GCC12 toolchain rightfully complains about duplicate symbols.

- Renamed "start" timestamp to "begin."