### PR TITLE
updated glRotatef in matrix.c: fixed a deg/rad issue

### DIFF
--- a/GL/matrix.c
+++ b/GL/matrix.c
@@ -181,11 +181,11 @@ void APIENTRY glRotatef(GLfloat angle, GLfloat x, GLfloat  y, GLfloat z) {
         0.0f, 0.0f, 0.0f, 1.0f
     };
 
-    float r = DEG2RAD * angle;
 #ifdef __DREAMCAST__
     float s, c;
-    fsincos(r, &s, &c);
+    fsincos(angle, &s, &c);
 #else
+    float r = DEG2RAD * angle;
     float c = cosf(r);
     float s = sinf(r);
 #endif


### PR DESCRIPTION
When building for Dreamcast, glRotatef uses fsincos to get the sine and the cosine for the provided angle. However, fsincos expects degrees, but it was called with radians. The fix is not to convert to radians in the first place as glRotatef is already called with degrees.