### PR TITLE
implement basic GL_Polygon offset

### DIFF
--- a/GL/draw.c
+++ b/GL/draw.c
@@ -759,6 +759,28 @@ GL_FORCE_INLINE GLuint calcFinalVertices(GLenum mode, GLuint count) {
     return count;
 }
 
+
+static void applyPolygonOffset(SubmissionTarget* target) {
+    if(!_glIsPolygonOffsetEnabled()) {
+        return;
+    }
+
+    GLfloat factor = _glGetPolygonOffsetFactor();
+    GLfloat units = _glGetPolygonOffsetUnits();
+    
+    /* Offset applied to w component. After perspective divide, depth = 1/w.
+     * Negative offset = smaller w = larger 1/w = wins depth test (GEQUAL).
+     * PVR_MIN_Z scale factor tuned for PVR depth precision. */
+    GLfloat offset = (factor + units) * PVR_MIN_Z;
+
+    Vertex* v = _glSubmissionTargetStart(target);
+    uint32_t i = target->count;
+    
+    while(i--) {
+        v->w += offset;  /* negative offset makes w smaller */
+        v++;
+    }
+}
 GL_FORCE_INLINE void submitVertices(GLenum mode, GLsizei first, GLuint count, GLenum type, const GLvoid* indices) {
     SubmissionTarget* const target = &SUBMISSION_TARGET;
     AlignedVector* const extras = target->extras;
@@ -821,6 +843,7 @@ GL_FORCE_INLINE void submitVertices(GLenum mode, GLsizei first, GLuint count, GL
     _glTnlLoadMatrix();
 
     generate(target, mode, first, count, (GLubyte*) indices, type);
+    applyPolygonOffset(target);
 
     _glTnlApplyEffects(target);
 

--- a/GL/private.h
+++ b/GL/private.h
@@ -473,6 +473,11 @@ GLfloat* _glGetLightModelSceneAmbient();
 LightSource* _glLightAt(GLuint i);
 GLboolean _glNearZClippingEnabled();
 
+GLboolean _glIsPolygonOffsetEnabled();
+GLfloat _glGetPolygonOffsetFactor();
+GLfloat _glGetPolygonOffsetUnits();
+
+
 GLboolean _glGPUStateIsDirty();
 void _glGPUStateMarkClean();
 void _glGPUStateMarkDirty();

--- a/GL/state.c
+++ b/GL/state.c
@@ -163,6 +163,20 @@ GLboolean _glIsScissorTestEnabled() {
     return GPUState.scissor_test_enabled;
 }
 
+
+GLboolean _glIsPolygonOffsetEnabled() {
+    return GPUState.polygon_offset_enabled;
+}
+
+GLfloat _glGetPolygonOffsetFactor() {
+    return GPUState.offset_factor;
+}
+
+GLfloat _glGetPolygonOffsetUnits() {
+    return GPUState.offset_units;
+}
+
+
 void _glRecalcEnabledLights() {
     GPUState.enabled_light_count = 0;
     for(GLubyte i = 0; i < MAX_GLDC_LIGHTS; ++i) {
@@ -267,6 +281,8 @@ GLenum _glGetGpuBlendDstFactor() {
         return GPU_BLEND_ONE;
     }
 }
+
+
 
 
 GLboolean _glCheckValidEnum(GLint param, GLint* values, const char* func) {


### PR DESCRIPTION
hacked in gl polygon offset 

Limitation:
Angled surfaces (like decals on sloped walls) won't get proper slope-based offset - as I just  add factor+units together instead of computing actual triangle depth slope.


shouldnt really be PR'd  as is needs testing.  But it worked for my limited usecase.
